### PR TITLE
Fix empty volume error when docker-compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - $PWD/Caddyfile:/etc/caddy/Caddyfile
+      - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
 
@@ -42,5 +42,4 @@ services:
 
 volumes:
   caddy_data:
-    external: true
   caddy_config:


### PR DESCRIPTION
Newly created templates are showing this error when trying to `docker-compose up`:

    external volume "" not found

The fix I'm suggesting doesn't require manual volume creation by default. 