### PR TITLE
Move from pyjwt to python-jose

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Union
 import jwt
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from jwt import PyJWTError
+from jose import JWTError, jwt
 from passlib.context import CryptContext
 from pydantic import BaseModel
 
@@ -113,7 +113,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> UserInDB:
             raise credentials_exception
         token_data = TokenData(username=username)
 
-    except PyJWTError:
+    except JWTError:
         raise credentials_exception
 
     user = get_user(fake_users_db, username=token_data.username)

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import Any, Optional, Union
 
-import jwt
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ typing-extensions==4.1.1
     # via pydantic
 uvicorn==0.17.6
     # via -r requirements.in
+python-jose[cryptography]==3.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
FastAPI recommends you to use python-jose instead of Pyjwt.

You can check it below. 
https://fastapi.tiangolo.com/tutorial/security/oauth2-jwt/?h=python+jose#install-python-jose